### PR TITLE
APS & BML: User can delete a topic without refreshing the page

### DIFF
--- a/app/assets/javascripts/topic.js
+++ b/app/assets/javascripts/topic.js
@@ -1,22 +1,31 @@
-var newTopicHandler = {
+var TopicHandler = {
 
   appendTopic: function(e, response){
-    $(".topic-list").append(response.new_topic)
+    var $new_topic = $(response.new_topic)
+    $(".topic-list").append($new_topic);
+    TopicHandler.toggleNewTopicForm();
   },
-  displayErrors: function(e, response){
-    console.log(response)
+
+  toggleNewTopicForm: function(){
+    $(".new-topic-form").fadeToggle();
+    $(".new-topic-form").find("input[type=text], textarea").val("");
+  },
+
+  removeTopicOnDelete: function(){
+    $(".topic-list").on('ajax:success', '.button_to', function(){
+      $(this).closest('.topic-name').remove();
+    })
   }
 
 }
 
+
 $(document).ready(function() {
-  $("#add-new-topic").on('click', toggleNewTopicForm);
-  $(".new-topic-form form").on('ajax:success', newTopicHandler.appendTopic)
-  $(".new-topic-form form").on('ajax:failure', newTopicHandler.displayErrors)
-  $(".new-topic-form").submit(toggleNewTopicForm);
+
+  $("#add-new-topic").on('click', TopicHandler.toggleNewTopicForm);
+
+  $(".new-topic-form form").on('ajax:success', TopicHandler.appendTopic)
+
+  TopicHandler.removeTopicOnDelete();
+
 })
-
-function toggleNewTopicForm(e) {
-  $(".new-topic-form").fadeToggle();
-}
-

--- a/app/assets/javascripts/topic.js
+++ b/app/assets/javascripts/topic.js
@@ -1,14 +1,32 @@
 var TopicHandler = {
 
-  appendTopic: function(e, response){
-    var $new_topic = $(response.new_topic)
-    $(".topic-list").append($new_topic);
-    TopicHandler.toggleNewTopicForm();
+  init: function(e, response){
+    if(response.responseJSON.errors){
+      TopicHandler.displayErrors(e, response);
+    } else {
+      TopicHandler.appendTopic(e, response)
+    }
   },
 
   toggleNewTopicForm: function(){
     $(".new-topic-form").fadeToggle();
     $(".new-topic-form").find("input[type=text], textarea").val("");
+  },
+
+  displayErrors: function(e, response){
+    TopicHandler.toggleNewTopicForm();
+    $("#new-topic-errors").html(response.responseJSON.errors[0]);
+  },
+
+  clearErrorsDiv: function() {
+    $("#new-topic-errors").html("");
+  },
+
+  appendTopic: function(e, response){
+    var $new_topic = $(response.responseJSON.new_topic)
+    $(".topic-list").append($new_topic);
+    TopicHandler.toggleNewTopicForm();
+    TopicHandler.clearErrorsDiv();
   },
 
   removeTopicOnDelete: function(){
@@ -20,11 +38,7 @@ var TopicHandler = {
 }
 
 $(document).ready(function() {
-
   $("#add-new-topic").on('click', TopicHandler.toggleNewTopicForm);
-
-  $(".new-topic-form form").on('ajax:success', TopicHandler.appendTopic)
-
+  $(".new-topic-form form").on('ajax:complete', TopicHandler.init)
   TopicHandler.removeTopicOnDelete();
-
 })

--- a/app/assets/javascripts/topic.js
+++ b/app/assets/javascripts/topic.js
@@ -19,7 +19,6 @@ var TopicHandler = {
 
 }
 
-
 $(document).ready(function() {
 
   $("#add-new-topic").on('click', TopicHandler.toggleNewTopicForm);

--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -7,15 +7,13 @@ class TopicsController < ApplicationController
   end
 
   def create
-    topic = Topic.new
-    topic.user_id = current_user.id || params[:topic][:user_id]
-    topic.name = params[:topic][:name]
-    if topic.save
-      render :json => { new_topic: render_to_string(partial: "topic", locals: { topic: topic })}
+    new_topic = Topic.new
+    new_topic.user_id = current_user.id || params[:topic][:user_id]
+    new_topic.name = params[:topic][:name]
+    if new_topic.save
+      render :json => { new_topic: render_to_string(partial: "topic", locals: { topic: new_topic })}
     else
-      # flash[:error] = topic.errors.full_messages
-      render :json => { errors: topic.errors.full_messages }
-      # redirect_to root_path
+      render :json => { errors: new_topic.errors.full_messages }
     end
   end
 

--- a/app/views/topics/_topic.html.erb
+++ b/app/views/topics/_topic.html.erb
@@ -1,4 +1,4 @@
 <div class="topic-name" id="topic-<%=topic.id%>">
   <%= link_to topic.name, topic_path(topic)%>
-  <%= button_to "Delete", { action: :destroy, id: topic.id }, { :class => 'delete-button', method: :delete } %>
+  <%= button_to "Delete", { action: :destroy, id: topic.id }, { :class => 'delete-button', remote: true, method: "delete" } %>
 </div>

--- a/app/views/topics/index.html.erb
+++ b/app/views/topics/index.html.erb
@@ -3,13 +3,13 @@
 <div>And wetness is the essence of beauty.</div>
 
 <div class="topic-list">
+  <div id="new-topic-errors"></div>
   <button id="add-new-topic"><i class="fa fa-plus-square-o" ></i>Add new</button>
   <div class="new-topic-form"> <%= render "new_topic_form" %> </div>
 
   <% @topics.all.each do |topic|%>
     <%= render 'topic', topic: topic %>
   <% end %>
-
 
   <div class="unaffiliated">
 

--- a/spec/features/topics_spec.rb
+++ b/spec/features/topics_spec.rb
@@ -48,13 +48,13 @@ feature 'User creates a topic' do
   end
 
   context "with invalid params", js: true do
-    xscenario "with no name" do
+    scenario "with no name" do
       click_on("Add new")
       click_on 'Create Topic'
       expect(page).to have_content("Name can't be blank")
     end
 
-    xscenario "with repeated name" do
+    scenario "with repeated name" do
       click_on("Add new")
       fill_in 'topic_name', with: topic.name
       click_on 'Create Topic'


### PR DESCRIPTION
Errors are displaying properly
Javascript for topics consolidated into one file

![satisfied_chewy](https://f.cloud.github.com/assets/5043885/1518778/cdc52c0a-4b42-11e3-9db2-65d4a43b5cb0.gif)
