### PR TITLE
Fix bugs

### DIFF
--- a/app/assets/stylesheets/layout.css.scss
+++ b/app/assets/stylesheets/layout.css.scss
@@ -129,3 +129,9 @@ button:hover, button:focus, button:active {
   text-indent: 10px;
   z-index: 1000;
 }
+
+@media screen and (max-width: 768px) {
+  .navbar ul {
+    float: left;
+  }
+}

--- a/app/assets/stylesheets/topics.css.scss
+++ b/app/assets/stylesheets/topics.css.scss
@@ -61,6 +61,7 @@
 // Topic
 
 .topic-name {
+  position: relative;
   margin: 3em auto;
   width: 65%;
   padding: 2em 1.74em;
@@ -112,7 +113,9 @@
   }
 
   .delete-button {
-    float: right;
+    position: absolute;
+    top: 3px;
+    right: 5px;
     font-size: 0.7em;
     font-weight: 200;
     color: #f0776c;

--- a/app/views/topics/_topic.html.erb
+++ b/app/views/topics/_topic.html.erb
@@ -1,4 +1,4 @@
 <div class="topic-name" id="topic-<%=topic.id%>" data-id="<%= topic.id %>">
-  <%= button_to "✖", { action: :destroy, id: topic.id }, { :class => 'delete-button', remote: true, method: "delete" } %>
+  <%= button_to "✖", { action: :destroy, id: topic.id }, { :class => 'delete-button', remote: true, method: "delete", data: { confirm: "Are you sure?" } } %>
   <div class="topic_link"><%= link_to topic.name, topic_path(topic)%></div>
 </div>


### PR DESCRIPTION
- fixed positioning bug in topic card
- fixed hover on delete-button
- added confirmation before deleting topic
- fix floating bug in navigation on mobile

@JonathanTR: 
Here, absolute positioning is the correct choice so the delete button will not increase the height of a card. The delete button should only be dependent on the card and not change the height of the card (which has overflow: auto; to adapt its height to its child elements size). The button is a child of card so position: absolute; takes it out of the regular element flow and basically places it on top of the card (so it is e.g. always clickable and :hover works and such).

Also, in terms of good UX; such a destructive action should be placed in either the top-right or the top-left corner so the chance of users clicking on it by accident is minimized.  Our content is text-align: left; so the delete button should be in the top-right corner of the card. On that note, I added a confirmation to delete.

Sounds good?

![200](https://f.cloud.github.com/assets/3147345/1641770/6b04fae6-5862-11e3-9785-56c141b4c783.gif)
