### PR TITLE
Fix hover width on source icons 

### DIFF
--- a/app/assets/stylesheets/sources.css.scss
+++ b/app/assets/stylesheets/sources.css.scss
@@ -15,7 +15,7 @@
       margin-bottom: 0.8em;
       height: 88px;
       width: 69px;
-      display: block;
+      display: inline-block;
     }
 
     a {


### PR DESCRIPTION
The hover on library sources was activating outside the bounds of source icon. I changed the .source img display property from 'block' to 'inline-block' to shrink-wrap the margins. Should fix this issue.
